### PR TITLE
JIRA-3257 Add support for re-entering a state to FSM

### DIFF
--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -152,11 +152,12 @@ namespace etl
       return state_id;
     }
 
-	//*******************************************
-	/// State ID to indicate "staying" in a state vs. re-entering it.
-	//	Messages can return this as a value to indicate no state transition.
-	//*******************************************
-	static etl::fsm_state_id_t stay() { return -1; }
+    //*******************************************
+    /// State ID to indicate "staying" in a state to differentiate staying from re-entering the state.
+    /// Messages can return this as a value to indicate no state transition.
+    //*******************************************
+    static etl::fsm_state_id_t stay() { return -1; }
+
 
   protected:
 
@@ -186,7 +187,7 @@ namespace etl
 
     virtual fsm_state_id_t process_event(etl::imessage_router& source, const etl::imessage& message) = 0;
 
-	virtual fsm_state_id_t on_enter_state() { return stay(); } // By default, do nothing.
+    virtual fsm_state_id_t on_enter_state() { return stay(); } // By default, do nothing.
     virtual void on_exit_state() {}  // By default, do nothing.
 
     //*******************************************
@@ -222,6 +223,12 @@ namespace etl
     {
     }
 
+	//*******************************************
+	/// State ID to indicate "staying" in a state vs. re-entering it.
+	//	Messages can return this as a value to indicate no state transition.
+	//*******************************************
+    static etl::fsm_state_id_t stay() { return -1; }
+
     //*******************************************
     /// Set the states for the FSM
     //*******************************************
@@ -244,23 +251,21 @@ namespace etl
     /// Starts the FSM.
     /// Can only be called once.
     /// Subsequent calls will do nothing.
-    ///\param call_on_enter_state If will call on_enter_state() for the first state. Default = true.
+    ///\param call_on_enter_state If true will call on_enter_state() for the first state. Default = true.
     //*******************************************
     void start(bool call_on_enter_state = true)
     {
-		  // Can only be started once.
-		  if (p_state == nullptr)
-		  {
-			  p_state = state_list[0];
-			  ETL_ASSERT(p_state != nullptr, ETL_ERROR(etl::fsm_null_state_exception));
+      // Can only be started once.
+      if (p_state == nullptr)
+      {
+        p_state = state_list[0];
+        ETL_ASSERT(p_state != nullptr, ETL_ERROR(etl::fsm_null_state_exception));
 
-			  if (call_on_enter_state)
-			  {
-				  etl::fsm_state_id_t next_state_id = p_state->on_enter_state();
-
-				  transition(next_state_id);
-			  }
-		  }
+        if (call_on_enter_state)
+        {
+          transition(p_state->on_enter_state());
+        }
+      }
     }
 
     //*******************************************
@@ -277,9 +282,7 @@ namespace etl
     //*******************************************
     void receive(etl::imessage_router& source, const etl::imessage& message)
     {
-        etl::fsm_state_id_t next_state_id = p_state->process_event(source, message);
-
-		transition(next_state_id);
+      transition(p_state->process_event(source, message));
     }
 
     using imessage_router::accepts;
@@ -345,20 +348,20 @@ namespace etl
 
   private:
 
-	  void transition(etl::fsm_state_id_t next_state_id)
-	  {
-		  // Have we changed state? (must be checked in while loop to account for state changes from on_enter_state)
-		  while (next_state_id != ifsm_state::stay())
-		  {
-			  ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
-			  etl::ifsm_state* p_next_state = state_list[next_state_id];
+    void transition(etl::fsm_state_id_t next_state_id)
+    {
+      // Have we changed state? (must be checked in while loop to account for state changes from on_enter_state)
+      while (next_state_id != ifsm_state::stay())
+      {
+        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+        etl::ifsm_state* p_next_state = state_list[next_state_id];
 
-			  p_state->on_exit_state();
-			  p_state = p_next_state;
+        p_state->on_exit_state();
+        p_state = p_next_state;
 
-			  next_state_id = p_state->on_enter_state();
-		  }
-	  }
+        next_state_id = p_state->on_enter_state();
+      }
+    }
 
 
     etl::ifsm_state*    p_state;          ///< A pointer to the current state.
@@ -389,8 +392,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -454,8 +457,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -518,8 +521,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -581,8 +584,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -642,8 +645,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -702,8 +705,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -761,8 +764,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -819,8 +822,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -875,8 +878,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -930,8 +933,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -984,8 +987,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -1037,8 +1040,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -1088,8 +1091,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -1138,8 +1141,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -1187,8 +1190,8 @@ namespace etl
     }
 
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 
@@ -1235,7 +1238,7 @@ namespace etl
     }
 
   protected:
-      
+
     virtual ~fsm_state()
     {
     }
@@ -1279,10 +1282,10 @@ namespace etl
       : ifsm_state(STATE_ID)
     {
     }
-  
+
   protected:
-      
-    ~fsm_state()
+
+    virtual ~fsm_state()
     {
     }
 

--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -216,6 +216,8 @@ namespace etl
     {
     }
 
+	static etl::fsm_state_id_t stay() { return -1; }
+
     //*******************************************
     /// Set the states for the FSM
     //*******************************************
@@ -257,6 +259,7 @@ namespace etl
 				  {
 					  p_last_state = p_state;
 					  next_state_id = p_state->on_enter_state();
+					  if (next_state_id == stay()) { break; }
 					  p_state = state_list[next_state_id];
 
 				  } while (p_last_state != p_state);
@@ -279,25 +282,27 @@ namespace etl
     void receive(etl::imessage_router& source, const etl::imessage& message)
     {
         etl::fsm_state_id_t next_state_id = p_state->process_event(source, message);
+		if (next_state_id == stay()) { return; }
         ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
 
         etl::ifsm_state* p_next_state = state_list[next_state_id];
 
         // Have we changed state?
-        if (p_next_state != p_state)
-        {
+        //if (p_next_state != p_state)
+        //{
           do
           {
             p_state->on_exit_state();
             p_state = p_next_state;
 
             next_state_id = p_state->on_enter_state();
+			if (next_state_id == stay()) { break; }
             ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
 
             p_next_state = state_list[next_state_id];
 
           } while (p_next_state != p_state); // Have we changed state again?
-        }
+        //}
     }
 
     using imessage_router::accepts;

--- a/include/etl/fsm.h
+++ b/include/etl/fsm.h
@@ -223,12 +223,6 @@ namespace etl
     {
     }
 
-	//*******************************************
-	/// State ID to indicate "staying" in a state vs. re-entering it.
-	//	Messages can return this as a value to indicate no state transition.
-	//*******************************************
-    static etl::fsm_state_id_t stay() { return -1; }
-
     //*******************************************
     /// Set the states for the FSM
     //*******************************************

--- a/include/etl/fsm_generator.h
+++ b/include/etl/fsm_generator.h
@@ -164,6 +164,13 @@ namespace etl
       return state_id;
     }
 
+    //*******************************************
+    /// State ID to indicate "staying" in a state to differentiate staying from re-entering the state.
+    /// Messages can return this as a value to indicate no state transition.
+    //*******************************************
+    static etl::fsm_state_id_t stay() { return -1; }
+
+
   protected:
 
     //*******************************************
@@ -178,7 +185,7 @@ namespace etl
     //*******************************************
     /// Destructor.
     //*******************************************
-    ~ifsm_state()
+    virtual ~ifsm_state()
     {
     }
 
@@ -192,7 +199,7 @@ namespace etl
 
     virtual fsm_state_id_t process_event(etl::imessage_router& source, const etl::imessage& message) = 0;
 
-    virtual fsm_state_id_t on_enter_state() { return state_id; } // By default, do nothing.
+    virtual fsm_state_id_t on_enter_state() { return stay(); } // By default, do nothing.
     virtual void on_exit_state() {}  // By default, do nothing.
 
     //*******************************************
@@ -228,6 +235,12 @@ namespace etl
     {
     }
 
+	//*******************************************
+	/// State ID to indicate "staying" in a state vs. re-entering it.
+	//	Messages can return this as a value to indicate no state transition.
+	//*******************************************
+    static etl::fsm_state_id_t stay() { return -1; }
+
     //*******************************************
     /// Set the states for the FSM
     //*******************************************
@@ -254,26 +267,17 @@ namespace etl
     //*******************************************
     void start(bool call_on_enter_state = true)
     {
-		  // Can only be started once.
-		  if (p_state == nullptr)
-		  {
-			  p_state = state_list[0];
-			  ETL_ASSERT(p_state != nullptr, ETL_ERROR(etl::fsm_null_state_exception));
+      // Can only be started once.
+      if (p_state == nullptr)
+      {
+        p_state = state_list[0];
+        ETL_ASSERT(p_state != nullptr, ETL_ERROR(etl::fsm_null_state_exception));
 
-			  if (call_on_enter_state)
-			  {
-				  etl::fsm_state_id_t next_state_id;
-				  etl::ifsm_state*    p_last_state;
-
-				  do
-				  {
-					  p_last_state = p_state;
-					  next_state_id = p_state->on_enter_state();
-					  p_state = state_list[next_state_id];
-
-				  } while (p_last_state != p_state);
-			  }
-		  }
+        if (call_on_enter_state)
+        {
+          transition(p_state->on_enter_state());
+        }
+      }
     }
 
     //*******************************************
@@ -290,26 +294,7 @@ namespace etl
     //*******************************************
     void receive(etl::imessage_router& source, const etl::imessage& message)
     {
-        etl::fsm_state_id_t next_state_id = p_state->process_event(source, message);
-        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
-
-        etl::ifsm_state* p_next_state = state_list[next_state_id];
-
-        // Have we changed state?
-        if (p_next_state != p_state)
-        {
-          do
-          {
-            p_state->on_exit_state();
-            p_state = p_next_state;
-
-            next_state_id = p_state->on_enter_state();
-            ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
-
-            p_next_state = state_list[next_state_id];
-
-          } while (p_next_state != p_state); // Have we changed state again?
-        }
+      transition(p_state->process_event(source, message));
     }
 
     using imessage_router::accepts;
@@ -372,7 +357,24 @@ namespace etl
       p_state = nullptr;
     }
 
+
   private:
+
+    void transition(etl::fsm_state_id_t next_state_id)
+    {
+      // Have we changed state? (must be checked in while loop to account for state changes from on_enter_state)
+      while (next_state_id != ifsm_state::stay())
+      {
+        ETL_ASSERT(next_state_id < number_of_states, ETL_ERROR(etl::fsm_state_id_exception));
+        etl::ifsm_state* p_next_state = state_list[next_state_id];
+
+        p_state->on_exit_state();
+        p_state = p_next_state;
+
+        next_state_id = p_state->on_enter_state();
+      }
+    }
+
 
     etl::ifsm_state*    p_state;          ///< A pointer to the current state.
     etl::ifsm_state**   state_list;       ///< The list of added states.
@@ -411,7 +413,7 @@ namespace etl
   cog.outl("")
   cog.outl("protected:")
   cog.outl("")
-  cog.outl("  ~fsm_state()")
+  cog.outl("  virtual ~fsm_state()")
   cog.outl("  {")
   cog.outl("  }")
   cog.outl("")
@@ -488,7 +490,7 @@ namespace etl
       cog.outl("")
       cog.outl("protected:")
       cog.outl("")
-      cog.outl("  ~fsm_state()")
+      cog.outl("  virtual ~fsm_state()")
       cog.outl("  {")
       cog.outl("  }")
       cog.outl("")
@@ -548,7 +550,7 @@ namespace etl
   cog.outl("")
   cog.outl("protected:")
   cog.outl("")
-  cog.outl("  ~fsm_state()")
+  cog.outl("  virtual ~fsm_state()")
   cog.outl("  {")
   cog.outl("  }")
   cog.outl("")

--- a/include/etl/fsm_generator.h
+++ b/include/etl/fsm_generator.h
@@ -235,12 +235,6 @@ namespace etl
     {
     }
 
-	//*******************************************
-	/// State ID to indicate "staying" in a state vs. re-entering it.
-	//	Messages can return this as a value to indicate no state transition.
-	//*******************************************
-    static etl::fsm_state_id_t stay() { return -1; }
-
     //*******************************************
     /// Set the states for the FSM
     //*******************************************


### PR DESCRIPTION
- Adds support for re-entering a state (previously, returning the same state index would not re-enter the state). This enables us to have abilities like Runaan's bowshot or Rayla's ultimate re-enter the same state when you press a button (this is how the old F# state machine worked).
- Also unifies logic between `start` and `receive` so that they both account for `on_state_exit` (previously, `on_state_exit` was ignored in `start` for some unknown reason)

Note: our previous changes to `fsm.h` are also included here, since they were only added to `fsm.h` which is a generated file, but not to `fsm_generator.h` which is the real place they belong.

For future reference, to run the code generator as I did in this PR, do the following:
Need to install cogapp:
`>pip install cogapp`
https://pypi.org/project/cogapp/

Generated using 16 messages options from cmd.exe inside the etl directory:
`>python -m cogapp -d -e -ofsm.h -DHandlers=16 fsm_generator.h`